### PR TITLE
Improved Formatter user experience and IO Handling for Large Files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,5 @@
 import { exec } from 'child_process';
-
 import * as vscode from 'vscode';
-
 import { Config, FormatterConfig } from './types';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -35,7 +33,7 @@ const registerFormatters = (
           const command = formatter.command
             .replace(/\${file}/g, document.fileName)
             .replace(/\${insertSpaces}/g, '' + options.insertSpaces)
-            .replace(/\${tabSize}/g, '' + options.tabSize.toString);
+            .replace(/\${tabSize}/g, '' + options.tabSize.toString());
 
           const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
           const backupFolder = vscode.workspace.workspaceFolders?.[0];
@@ -45,15 +43,35 @@ const registerFormatters = (
             outputChannel.appendLine(`Starting formatter: ${command}`);
             const originalDocumentText = document.getText();
 
-            const process = exec(command, { cwd }, (error, stdout, stderr) => {
-              if (error) {
-                outputChannel.appendLine(`Formatter failed: ${command}\nStderr:\n${stderr}`);
-                reject(error);
+            const process = exec(command, { cwd });
+
+            let stdout = '';
+            let stderr = '';
+
+            process.stdout?.on('data', (chunk) => {
+              stdout += chunk;
+            });
+
+            process.stderr?.on('data', (chunk) => {
+              stderr += chunk;
+            });
+
+            process.on('close', (code, signal) => {
+              if (code !== 0) {
+                const reason = signal ? `terminated by signal ${signal} (likely due to a timeout or external termination)` : `exited with code ${code}`;
+                const message = `Formatter failed: ${command}\nReason: ${reason}`;
+                outputChannel.appendLine(message);
+                if (stderr !== '')
+                  outputChannel.appendLine(`Stderr:\n${stderr}`);
+                vscode.window.showErrorMessage(message);
+                reject(new Error(message));
+                return;
               }
 
               if (originalDocumentText.length > 0 && stdout.length === 0) {
                 outputChannel.appendLine(`Formatter returned nothing - not applying changes.`);
                 resolve([]);
+                return;
               }
 
               const documentRange = new vscode.Range(
@@ -63,9 +81,10 @@ const registerFormatters = (
 
               outputChannel.appendLine(`Finished running formatter: ${command}`);
               if (stderr.length > 0)
-                outputChannel.appendLine(`Possible issues ocurred:\n${stderr}`);
+                outputChannel.appendLine(`Possible issues occurred:\n${stderr}`);
 
               resolve([new vscode.TextEdit(documentRange, stdout)]);
+              return;
             });
 
             process.stdin?.write(originalDocumentText);
@@ -78,4 +97,4 @@ const registerFormatters = (
 };
 
 // this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { spawn } from 'child_process';
 import * as vscode from 'vscode';
 import { Config, FormatterConfig } from './types';
 
@@ -30,36 +30,38 @@ const registerFormatters = (
 
       return vscode.languages.registerDocumentFormattingEditProvider(formatter.languages, {
         provideDocumentFormattingEdits(document, options) {
-          const command = formatter.command
+          const commandParts = formatter.command
             .replace(/\${file}/g, document.fileName)
             .replace(/\${insertSpaces}/g, '' + options.insertSpaces)
-            .replace(/\${tabSize}/g, '' + options.tabSize.toString());
+            .replace(/\${tabSize}/g, '' + options.tabSize.toString())
+            .split(' ');
 
           const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
           const backupFolder = vscode.workspace.workspaceFolders?.[0];
           const cwd = workspaceFolder?.uri?.fsPath || backupFolder?.uri.fsPath;
 
           return new Promise<vscode.TextEdit[]>((resolve, reject) => {
-            outputChannel.appendLine(`Starting formatter: ${command}`);
+            outputChannel.appendLine(`Starting formatter: ${formatter.command}`);
             const originalDocumentText = document.getText();
 
-            const process = exec(command, { cwd });
+            const [command, ...args] = commandParts;
+            const process = spawn(command, args, { cwd });
 
             let stdout = '';
             let stderr = '';
 
-            process.stdout?.on('data', (chunk) => {
+            process.stdout.on('data', (chunk) => {
               stdout += chunk;
             });
 
-            process.stderr?.on('data', (chunk) => {
+            process.stderr.on('data', (chunk) => {
               stderr += chunk;
             });
 
             process.on('close', (code, signal) => {
               if (code !== 0) {
                 const reason = signal ? `terminated by signal ${signal} (likely due to a timeout or external termination)` : `exited with code ${code}`;
-                const message = `Formatter failed: ${command}\nReason: ${reason}`;
+                const message = `Formatter failed: ${formatter.command}\nReason: ${reason}`;
                 outputChannel.appendLine(message);
                 if (stderr !== '')
                   outputChannel.appendLine(`Stderr:\n${stderr}`);
@@ -79,7 +81,7 @@ const registerFormatters = (
                 document.lineAt(document.lineCount - 1).rangeIncludingLineBreak.end,
               );
 
-              outputChannel.appendLine(`Finished running formatter: ${command}`);
+              outputChannel.appendLine(`Finished running formatter: ${formatter.command}`);
               if (stderr.length > 0)
                 outputChannel.appendLine(`Possible issues occurred:\n${stderr}`);
 
@@ -87,8 +89,8 @@ const registerFormatters = (
               return;
             });
 
-            process.stdin?.write(originalDocumentText);
-            process.stdin?.end();
+            process.stdin.write(originalDocumentText);
+            process.stdin.end();
           });
         },
       });


### PR DESCRIPTION
VSCode terminates the formatting process if it takes longer than the set timeout (~5 seconds). In my case, formatting a large file (>100k lines) takes approximately 10 seconds, causing the formatter to fail without any notification or visible error.

This change enhances the user experience by:

- Providing more detailed failure information in the custom-local-formatters output channel.
- Triggering an error notification via the VSCode API, which can be silenced if the user prefers not to be notified.

Additionally, I improved the formatter's IO handling. Previously, when working with large files, I observed Node.js errors related to an overfilled stdout buffer. Now, we use spawn instead of exec and the output is read in chunks, preventing such issues. With that change the system can also handle much larger files
