### PR TITLE
feat: allow failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,11 @@
                 "type": "boolean",
                 "default": false
               },
+							"allowFailures": {
+								"type": "boolean",
+								"default": false,
+								"description": "If set to true, show an alert if the formatting fails."
+							},
               "languages": {
                 "type": "array",
                 "description": "Array of VSCode language identifiers. See https://code.visualstudio.com/docs/languages/identifiers",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,7 +87,7 @@ const registerFormatters = (
                 const message = `Formatter failed: ${formatter.command}\nReason: ${reason}`;
                 outputChannel.appendLine(message);
                 if (stderr !== "") outputChannel.appendLine(`Stderr:\n${stderr}`);
-                vscode.window.showErrorMessage(message);
+								if (!formatter.allowFailures) vscode.window.showErrorMessage(message);
                 reject(new Error(message));
                 return;
               }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,4 +10,5 @@ export type FormatterConfig = {
       };
   disabled?: boolean;
   languages: string[];
+	allowFailures?: boolean;
 };


### PR DESCRIPTION
This pull request adds a `allowFailures` option to formatter configs. When this option is enabled, no error message is shown if there is an error when formatting.

This is useful when using per-project formatters:
```json
"customLocalFormatters.formatters": [
	{
		"command": "./vendor/bin/mago fmt --stdin-input",
		"languages": ["php"],
		"allowFailures": true
	}
],
```
In the case above, not every project I work on use Mago, so I don't want to get spammed of error messages when this fails.