### PR TITLE
fix: remove call to non-existant function toString()

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ const registerFormatters = (
           const command = commandTemplate
             .replace(/\${file}/g, document.fileName)
             .replace(/\${insertSpaces}/g, "" + options.insertSpaces)
-            .replace(/\${tabSize}/g, "" + options.tabSize.toString());
+            .replace(/\${tabSize}/g, "" + options.tabSize);
 
           const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
           const backupFolder = vscode.workspace.workspaceFolders?.[0];


### PR DESCRIPTION
Afaik, the conversion to string is already done implicitely with the `"" +` prefix. I am no JS/TS expert, but this change enabled me to actually benefit from the `${tabSize}` placeholder on a remote linux machine (never tested the extention locally)