### PR TITLE
Also include stderr+stdout in error messages if non-empty

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,10 +88,10 @@ const registerFormatters = (
                   `Formatter failed: ${formatter.command}`,
                   `Reason: ${reason}`
                 ];
-                if (stdout != "") {
+                if (stdout !== "") {
                   messages.push(`stdout: ${stdout}`);
                 }
-                if (stderr != "") {
+                if (stderr !== "") {
                   messages.push(`stderr: ${stderr}`);
                 }
                 const message = messages.join("\n");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,17 @@ const registerFormatters = (
                 const reason = signal
                   ? `terminated by signal ${signal} (likely due to a timeout or external termination)`
                   : `exited with code ${code}`;
-                const message = `Formatter failed: ${formatter.command}\nReason: ${reason}`;
+                const messages = [
+                  `Formatter failed: ${formatter.command}`,
+                  `Reason: ${reason}`
+                ];
+                if (stdout != "") {
+                  messages.push(`stdout: ${stdout}`);
+                }
+                if (stderr != "") {
+                  messages.push(`stderr: ${stderr}`);
+                }
+                const message = messages.join("\n");
                 outputChannel.appendLine(message);
                 if (stderr !== "") outputChannel.appendLine(`Stderr:\n${stderr}`);
                 vscode.window.showErrorMessage(message);


### PR DESCRIPTION
This is great for understanding why the formatter failed.

### Example

Here I have deliberately introduced a sytnax error in my python file:

This is what it looked like before:

<img width="881" height="338" alt="Screenshot From 2025-09-03 17-20-31" src="https://github.com/user-attachments/assets/f5056c05-3835-455f-8bde-080102f83622" />

Now:

<img width="881" height="338" alt="Screenshot From 2025-09-03 17-19-03" src="https://github.com/user-attachments/assets/aec102e3-7503-4394-8a3d-6067965d452e" />

